### PR TITLE
Capture a relationship between branch and branch commits

### DIFF
--- a/lib/branch_base/database.rb
+++ b/lib/branch_base/database.rb
@@ -43,21 +43,20 @@ module BranchBase
           FOREIGN KEY (repo_id) REFERENCES repositories (repo_id)
         );
 
-        CREATE INDEX IF NOT EXISTS idx_commits_repo_id ON commits (repo_id);
-        CREATE INDEX IF NOT EXISTS idx_commits_author ON commits (author);
-        CREATE INDEX IF NOT EXISTS idx_commits_committer ON commits (committer);
-
         CREATE TABLE IF NOT EXISTS branches (
           branch_id INTEGER PRIMARY KEY AUTOINCREMENT,
           repo_id INTEGER NOT NULL,
           name TEXT NOT NULL,
-          head_commit TEXT NOT NULL,
-          FOREIGN KEY (repo_id) REFERENCES repositories (repo_id),
-          FOREIGN KEY (head_commit) REFERENCES commits (commit_hash)
+          FOREIGN KEY (repo_id) REFERENCES repositories (repo_id)
         );
 
-        CREATE INDEX IF NOT EXISTS idx_branches_repo_id ON branches (repo_id);
-        CREATE INDEX IF NOT EXISTS idx_branches_head_commit ON branches (head_commit);
+        CREATE TABLE IF NOT EXISTS branch_commits (
+          branch_id INTEGER NOT NULL,
+          commit_hash TEXT NOT NULL,
+          PRIMARY KEY (branch_id, commit_hash),
+          FOREIGN KEY (branch_id) REFERENCES branches (branch_id),
+          FOREIGN KEY (commit_hash) REFERENCES commits (commit_hash)
+        );
 
         CREATE TABLE IF NOT EXISTS files (
           file_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -67,9 +66,6 @@ module BranchBase
           FOREIGN KEY (repo_id) REFERENCES repositories (repo_id),
           FOREIGN KEY (latest_commit) REFERENCES commits (commit_hash)
         );
-
-        CREATE INDEX IF NOT EXISTS idx_files_repo_id ON files (repo_id);
-        CREATE INDEX IF NOT EXISTS idx_files_file_path ON files (file_path);
 
         CREATE TABLE IF NOT EXISTS commit_files (
           commit_hash TEXT NOT NULL,
@@ -88,6 +84,12 @@ module BranchBase
           FOREIGN KEY (parent_hash) REFERENCES commits (commit_hash)
         );
 
+        CREATE INDEX IF NOT EXISTS idx_commits_repo_id ON commits (repo_id);
+        CREATE INDEX IF NOT EXISTS idx_commits_author ON commits (author);
+        CREATE INDEX IF NOT EXISTS idx_commits_committer ON commits (committer);
+        CREATE INDEX IF NOT EXISTS idx_branches_repo_id ON branches (repo_id);
+        CREATE INDEX IF NOT EXISTS idx_files_repo_id ON files (repo_id);
+        CREATE INDEX IF NOT EXISTS idx_files_file_path ON files (file_path);
         CREATE INDEX IF NOT EXISTS idx_commit_parents_commit_hash ON commit_parents (commit_hash);
         CREATE INDEX IF NOT EXISTS idx_commit_parents_parent_hash ON commit_parents (parent_hash);
       SQL

--- a/lib/branch_base/repository.rb
+++ b/lib/branch_base/repository.rb
@@ -4,12 +4,32 @@ require "rugged"
 
 module BranchBase
   class Repository
+    attr_reader :repo
+
     def initialize(repo_path)
       @repo = Rugged::Repository.new(repo_path)
     end
 
-    def walk(&block)
-      @repo.walk(@repo.head.target.oid, Rugged::SORT_TOPO, &block)
+    def walk(branch_name = nil, &block)
+      # Use the provided branch's head commit OID if a branch name is given,
+      # otherwise, use the repository's HEAD commit OID.
+      oid =
+        if branch_name
+          branch = @repo.branches[branch_name]
+          raise ArgumentError, "Branch not found: #{branch_name}" unless branch
+          branch.target.oid
+        else
+          @repo.head.target.oid
+        end
+
+      @repo.walk(oid, Rugged::SORT_TOPO, &block)
+    end
+
+    def default_branch_name
+      head_ref = @repo.head.name
+      head_ref.sub(%r{^refs/heads/}, "")
+    rescue Rugged::ReferenceError
+      nil
     end
 
     def path

--- a/spec/branch_base/database_spec.rb
+++ b/spec/branch_base/database_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe(BranchBase::Database) do
         commit_files
         commit_parents
         sqlite_sequence
+        branch_commits
       ]
       expect(tables.flatten).to match_array(expected_tables)
     end


### PR DESCRIPTION
One commit can also be related to multiple branches.

This does slow down the sync process, so only syncing for default branch. Still slow after that, so can wait to introduce this